### PR TITLE
Enhancing ExportTablature() so that the TablatureWriter's wrap positi…

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	w := tabio.NewTablatureWriter(os.Stdout, 20)
 	// f, _ := os.OpenFile("guitar_tab.txt", os.O_RDWR|os.O_CREATE, 0755)
-	// w := tabio.NewTablatureWriter(f, 20)
+	// w := tabio.NewTablatureWriter(f, 110)
 
 	for {
 		input, _ := reader.ReadString('\n')

--- a/tabio/tabio.go
+++ b/tabio/tabio.go
@@ -2,9 +2,8 @@ package tabio
 
 import (
 	"bufio"
-	"bytes"
-	"fmt"
 	"github.com/Guitarbum722/go-tabs/instrument"
+	"github.com/pkg/errors"
 	"io"
 )
 
@@ -14,6 +13,7 @@ import (
 type TablatureWriter struct {
 	*bufio.Writer
 	WrapPosition int
+	totalLength  int
 	tb           tablatureBuilder
 }
 
@@ -23,9 +23,11 @@ type tablatureBuilder struct {
 
 // NewTablatureWriter creates a buffered writer to be used for staging tablature
 func NewTablatureWriter(w io.Writer, pos int) *TablatureWriter {
+
 	return &TablatureWriter{
 		bufio.NewWriter(w),
-		20,
+		pos,
+		0,
 		tablatureBuilder{
 			make(map[byte][]byte),
 		},
@@ -39,20 +41,8 @@ func StageTablature(i instrument.Instrument, w *TablatureWriter) {
 
 	for k, v := range i.Fretboard() {
 
-		// labels each instrument's "string" with a prefix
-		if len(w.tb.builder[k]) == 0 {
-			w.tb.builder[k] = append(w.tb.builder[k], k, ':', ' ')
-		}
-
-		// adds the first newline after each line of tablature.
-		// the newline is added to the end of each line of tablature
-		if !bytes.Contains(w.tb.builder[k], []byte("\n")) {
-			w.tb.builder[k] = append(w.tb.builder[k], []byte(v)...)
-			w.tb.builder[k] = append(w.tb.builder[k], '\n')
-		} else {
-			w.tb.builder[k] = append(w.tb.builder[k][:len(w.tb.builder[k])-1], []byte(v)...)
-			w.tb.builder[k] = append(w.tb.builder[k], '\n')
-		}
+		w.tb.builder[k] = append(w.tb.builder[k], []byte(v)...)
+		w.totalLength = len(w.tb.builder[k])
 	}
 
 	return
@@ -61,9 +51,32 @@ func StageTablature(i instrument.Instrument, w *TablatureWriter) {
 // ExportTablature will flush the bufferred writer to the io.Writer of which it was initialized
 func ExportTablature(i instrument.Instrument, w *TablatureWriter) error {
 
-	for _, v := range i.Order() {
+	var done int
 
-		fmt.Fprint(w, string(w.tb.builder[v]))
+	for ; done < w.totalLength; done += w.WrapPosition {
+
+		for _, v := range i.Order() {
+
+			w.Write([]byte{v, ':', ' '})
+
+			// use the TablatureWriter's wrap position to determine when to continue a new
+			// tablature section in the output
+			if w.totalLength < w.WrapPosition {
+				if _, err := w.Write(w.tb.builder[v][:w.totalLength]); err != nil {
+					return errors.Wrap(err, "write to buffer failed")
+				}
+			} else if (done + w.WrapPosition) < w.totalLength {
+				if _, err := w.Write(w.tb.builder[v][done:(done + w.WrapPosition)]); err != nil {
+					return errors.Wrap(err, "write to buffer failed")
+				}
+			} else {
+				if _, err := w.Write(w.tb.builder[v][done:(w.totalLength)]); err != nil {
+					return errors.Wrap(err, "write to buffer failed")
+				}
+			}
+			w.WriteByte('\n')
+		}
+		w.WriteByte('\n')
 	}
 
 	w.Flush()


### PR DESCRIPTION
…on can be utilized.  Removing the prepending of the string-note prefixes in StageTablature() since the prefixes are really only needed when output.  So, the prefixes are prepended in the Writing steps of ExportTablature()