### PR TITLE
remove ResetTimer() calls 

### DIFF
--- a/instrument/instrument_test.go
+++ b/instrument/instrument_test.go
@@ -59,7 +59,6 @@ func TestParseFingerBoard(t *testing.T) {
 
 func BenchmarkParseFingerBoard(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ParseFingerBoard(parseFingerBoardCases[0].input)
 	}
@@ -67,7 +66,6 @@ func BenchmarkParseFingerBoard(b *testing.B) {
 
 func BenchmarkNewInstrument(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		NewInstrument(newInstrumentCases[0].inputType)
 	}


### PR DESCRIPTION
There were a couple of benchmarks with ResetTimer() calls that were unnecessary.  They have been removed.